### PR TITLE
Arduino Mega 1280/2560 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ noise generator and duty cycle control, amongst other things.
 This Arduino sketch tests an AY8930 chip by setting up some initial configuration and generating sounds.
 The Arduino's ADC (analog-to-digital converter) is used, along with a pot, to control the sound generator.
 
+## Arduino Wiring
+
+| PSG Signal | UNO Pin | Mega2560 Pin |
+|------------|---------|--------------|
+| D0         | 6       | 22           |
+| D1         | 7       | 23           |
+| D2         | 8       | 24           |
+| D3         | 9       | 25           |
+| D4         | 10      | 26           |
+| D5         | 11      | 27           |
+| D6         | 12      | 28           |
+| D7         | 13      | 29           |
+| CLK        | 3       | 9            |
+| BDIR       | 4       | 21           |
+| BC1        | 5       | 20           |
+
 ## Test Plan
 We want to verify both that the chip works and that it has the
 enhanced functionality (i.e. that it really is an AY8930).

--- a/testAY8930.ino
+++ b/testAY8930.ino
@@ -1,10 +1,17 @@
 /* testAY8930 --- simple sketch to drive the AY8930 sound chip      2017-02-09 */
 /* Copyright (c) 2017 John Honniball                                           */
 
-#define CLK_PIN   (3)
-#define BDIR_PIN  (4)
-#define BC1_PIN   (5)
-#define D0_PIN    (6)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+# define CLK_PIN   (9)
+# define BDIR_PIN  (4)
+# define BC1_PIN   (5)
+# define D0_PIN    (6)
+#else
+# define CLK_PIN   (3)
+# define BDIR_PIN  (4)
+# define BC1_PIN   (5)
+# define D0_PIN    (6)
+#endif
 
 // Register numbers 0-15 common to AY-3-8910; 16-31 unique to AY8930
 #define TONEPERIODA_REG     (0)
@@ -68,6 +75,8 @@ void setup(void)
   Serial.begin(9600);
 
   initPSG();
+
+  return;
   
   setNoiseMasks(0x55, 0xaa);   // Set up noise generator
   setNoisePeriod(2);
@@ -114,7 +123,7 @@ void initPSG(void)
 {
   int i;
 
-  // Generate 2MHz clock on Pin 3
+  // Generate 2MHz clock on Pin 3 (pin 9 on Mega128/256)
   pinMode(CLK_PIN, OUTPUT);
   TCCR2A = 0x23;
   TCCR2B = 0x09;

--- a/testAY8930.ino
+++ b/testAY8930.ino
@@ -2,15 +2,17 @@
 /* Copyright (c) 2017 John Honniball                                           */
 
 #define BOBS_MEGA
+// #define SLOW
+
 
 #ifdef BOBS_MEGA
 # define CLK_PIN   (9)
-# define BDIR_PIN  (21)
-# define BC1_PIN   (20)
+# define BDIR_PIN  (20)
+# define BC1_PIN   (19)
 # define D0_PIN    (22)
 
-# define BC1_BIT   (1 << 1)
-# define BDIR_BIT  (1 << 0)
+# define BC1_BIT   (1 << 2)
+# define BDIR_BIT  (1 << 1)
 #else
 # define CLK_PIN   (3)
 # define BDIR_PIN  (4)
@@ -83,8 +85,6 @@ void setup(void)
   Serial.begin(9600);
 
   initPSG();
-
-  return;
   
   setNoiseMasks(0x55, 0xaa);   // Set up noise generator
   setNoisePeriod(2);
@@ -131,7 +131,7 @@ void initPSG(void)
 {
   int i;
 
-  // Generate 2MHz clock on Pin 3 (pin 9 on Mega128/256)
+  // Generate 2MHz clock on Pin 3 (pin 9 on Mega1280/2560)
   pinMode(CLK_PIN, OUTPUT);
   TCCR2A = 0x23;
   TCCR2B = 0x09;
@@ -139,8 +139,6 @@ void initPSG(void)
   OCR2B = 1;
 
   delay(10);
-
-  return;
   
   // BDIR pin
   pinMode(BDIR_PIN, OUTPUT);

--- a/testAY8930.ino
+++ b/testAY8930.ino
@@ -1,11 +1,12 @@
 /* testAY8930 --- simple sketch to drive the AY8930 sound chip      2017-02-09 */
 /* Copyright (c) 2017 John Honniball                                           */
 
-#define BOBS_MEGA
 // #define SLOW
 
 
-#ifdef BOBS_MEGA
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+# define BOARD_MEGA
+
 # define CLK_PIN   (9)
 # define BDIR_PIN  (20)
 # define BC1_PIN   (19)
@@ -366,7 +367,7 @@ void ay8930write(const int a0, const int val)
   digitalWrite(BC1_PIN, LOW);  // BC1 LOW
 #else
 
-# ifdef BOBS_MEGA
+# ifdef BOARD_MEGA
   PORTA = val;
 # else
   // D0-D1 on Port D bits 6 and 7; D2-D7 on Port B bits 0-5


### PR DESCRIPTION
Added defs for the Mega. Data is a single port so writing is nice and simple. OCR2B pin is pin 9 on Mega and not pin 3 as on the smaller boards. BDIR and BC1 are also on different pins. Tested in both slow and fast modes.

No worries if you don't want it :)

-Bob